### PR TITLE
BugFixNombreRelacionConceptoAplicable

### DIFF
--- a/app/Models/AjusteCatalogo.php
+++ b/app/Models/AjusteCatalogo.php
@@ -20,7 +20,7 @@ class AjusteCatalogo extends Model
 
     public function conceptosAplicables(): MorphMany
     {
-        return $this->morphMany(ConceptoAplicable::class, 'conceptosAplicables', 'modelo', 'id_modelo');
+        return $this->morphMany(ConceptoAplicable::class, 'origen', 'modelo', 'id_modelo');
     }
 
     public function tipoTomaAplicable(): MorphMany

--- a/app/Models/ConceptoAplicable.php
+++ b/app/Models/ConceptoAplicable.php
@@ -21,7 +21,7 @@ class ConceptoAplicable extends Model
         "rango_maximo",
     ];
 
-    public function conceptosAplicables(): MorphTo
+    public function origen(): MorphTo
     {
         return $this->morphTo(__FUNCTION__, 'modelo', 'id_modelo');
     }

--- a/app/Models/ConvenioCatalogo.php
+++ b/app/Models/ConvenioCatalogo.php
@@ -20,7 +20,7 @@ class ConvenioCatalogo extends Model
 
     public function conceptosAplicables() : MorphMany
     {
-        return $this->morphMany(ConceptoAplicable::class, 'conceptosAplicables', 'modelo', 'id_modelo');
+        return $this->morphMany(ConceptoAplicable::class, 'origen', 'modelo', 'id_modelo');
     }
 
     public function Convenio() : HasMany

--- a/app/Models/DescuentoCatalogo.php
+++ b/app/Models/DescuentoCatalogo.php
@@ -26,7 +26,7 @@ class DescuentoCatalogo extends Model
 
     public function conceptosAplicables(): MorphMany
     {
-        return $this->morphMany(ConceptoAplicable::class, 'conceptosAplicables', 'modelo', 'id_modelo');
+        return $this->morphMany(ConceptoAplicable::class, 'origen', 'modelo', 'id_modelo');
     }
 
     public function tipoTomaAplicable(): MorphMany

--- a/app/Services/AtencionUsuarios/ConceptoAplicableService.php
+++ b/app/Services/AtencionUsuarios/ConceptoAplicableService.php
@@ -48,7 +48,7 @@ class ConceptoAplicableService{
       }
     } catch (Exception $ex) {
       return response()->json([
-        'error' => 'Ocurrio un error al registrar el la configuracion del concepto.'.$ex
+        'error' => 'Ocurrio un error al registrar la configuracion del concepto.'.$ex
         ],400); 
     }
     
@@ -61,7 +61,7 @@ class ConceptoAplicableService{
       if ($data == "ajuste_catalogo" || $data == "descuento_catalogo" || $data == "convenio_catalogo") {
         $conceptosAplicables = ConceptoAplicable::where('modelo',$data)
         ->with('concepto')
-        ->with('conceptosAplicables')
+        ->with('origen')
         ->get();
         return $conceptosAplicables;
       }
@@ -83,7 +83,7 @@ class ConceptoAplicableService{
     try {
       $conceptosAplicables = ConceptoAplicable::where('id_concepto_catalogo',$data)
       ->with('concepto')
-      ->with('conceptosAplicables')
+      ->with('origen')
       ->get();
 
       if ($conceptosAplicables) {


### PR DESCRIPTION
Cambio de nombre de la relacion "conceptosAplicables" a "origen" en el modelo ConceptoAplicable, esto con el fin de que sea igual al manejo de nombres del resto de las tablas polimorficas